### PR TITLE
feat: แจ้งกลุ่ม Telegram เมื่อปิดงานร้องเรียน (close-tk)

### DIFF
--- a/pages/api/submittedreports/update-status.js
+++ b/pages/api/submittedreports/update-status.js
@@ -1,10 +1,21 @@
 // /pages/api/submittedreports/update-status.js
 import dbConnect from "@/lib/dbConnect";
 import SubmittedReport from "@/models/SubmittedReport";
+import Assignment from "@/models/Assignment";
+import mongoose from "mongoose";
 import { n8n } from "@/lib/n8nWebhook";
 import { logAuditEvent } from "@/lib/auditLogger";
 import { linePush, formatStatusMessage, buildMessages } from "@/lib/lineMessaging";
 import { getAuth } from "@clerk/nextjs/server";
+
+// สถานะที่ถือว่า "ปิดงาน" — ตรงกับปุ่มปิดเรื่องใน manage-complaints.jsx
+const CLOSED_STATUS = "ดำเนินการเสร็จสิ้น";
+// webhook แจ้งกลุ่ม Telegram เมื่อปิดงาน (n8n "Api All" → node close-tk)
+const CLOSE_WEBHOOK_URL = "https://primary-production-a1769.up.railway.app/webhook/close-tk";
+
+// schema ย่อ inline สำหรับ lookup ชื่อ officer (เลี่ยง model conflict ระหว่าง handlers)
+const UserNameSchema = new mongoose.Schema({ name: String }, { collection: "users", strict: false });
+const User = mongoose.models.User || mongoose.model("User", UserNameSchema);
 
 export default async function handler(req, res) {
   await dbConnect();
@@ -69,6 +80,36 @@ export default async function handler(req, res) {
             firstImage
           )
         ).catch((err) => console.error("[LINE] Push failed:", err));
+      }
+
+      // แจ้งกลุ่ม Telegram เมื่อปิดงาน — fire-and-forget (ไม่ block response, ไม่โยน error ถ้า n8n ล่ม)
+      if (status === CLOSED_STATUS) {
+        (async () => {
+          try {
+            let officerName = "เจ้าหน้าที่";
+            const assignment = await Assignment.findOne({ complaintId })
+              .sort({ assignedAt: -1 })
+              .lean();
+            if (assignment?.userId) {
+              const officer = await User.findById(assignment.userId).select("name").lean();
+              if (officer?.name) officerName = officer.name;
+            }
+
+            const r = await fetch(CLOSE_WEBHOOK_URL, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                complaintId: updated.complaintId || String(complaintId),
+                community: existing?.community || "-",
+                fullName: existing?.isConfidential ? "ไม่เปิดเผย" : (existing?.fullName || "ไม่ระบุ"),
+                officerName,
+              }),
+            });
+            if (!r.ok) console.error("🚨 close-tk webhook failed:", r.status, await r.text());
+          } catch (err) {
+            console.error("[close-tk] notify failed:", err);
+          }
+        })();
       }
 
       res.status(200).json(updated);


### PR DESCRIPTION
## สรุป
เมื่อแอดมินกดปิดเรื่องร้องเรียน (status = "ดำเนินการเสร็จสิ้น") ระบบจะส่งข้อความสรุปเข้ากลุ่ม Telegram SMART-TAKHLI

ตัวอย่างข้อความ:
```
✅ ปิดเรื่องเรียบร้อยแล้ว

🆔 คำร้อง: TKC-68000463
🏘️ ชุมชน: ตาคลีใหญ่
👤 ผู้แจ้ง: เฉลิมพล กฤตภาสพงศ์
🧑‍💼 ดำเนินการโดย: สมชาย ใจดี
```

## การเปลี่ยนแปลง
- **`pages/api/submittedreports/update-status.js`**: เมื่อ status = "ดำเนินการเสร็จสิ้น" → lookup ชื่อ officer (Assignment → User.name, fallback "เจ้าหน้าที่") แล้ว fire-and-forget POST ไป n8n webhook `close-tk` (ไม่ block response, ไม่ล้มถ้า n8n ล่ม) — ผู้แจ้งเคารพ `isConfidential`
- **n8n "Api All"** (นอก repo): เพิ่ม webhook `close-tk` → Telegram `sendMessage` สร้าง body ด้วย `JSON.stringify` กัน newline/quote พัง — publish แล้ว

## ทดสอบ
- ✅ lint ผ่าน (no warnings)
- ✅ ทดสอบ webhook `close-tk` end-to-end: Telegram ตอบ `ok:true` (message_id 664) ข้อความเข้ากลุ่มถูกต้องครบ 4 บรรทัด

🤖 Generated with [Claude Code](https://claude.com/claude-code)